### PR TITLE
Revert "tasks/main.yml: Validate systemd unit files"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,6 @@
   template:
     src: systemd-redis.service.j2
     dest: /lib/systemd/system/redis.service
-    validate: systemd-analyze verify %s
   notify: Reload systemd daemon
 
 - name: Remove redis-server.service


### PR DESCRIPTION
Reverts stuvusIT/redis#18
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232